### PR TITLE
add AXIS_XR

### DIFF
--- a/src/proj2d/Matrix2d.ts
+++ b/src/proj2d/Matrix2d.ts
@@ -11,7 +11,9 @@ namespace pixi_projection {
 		FREE = 1,
 		AXIS_X = 2,
 		AXIS_Y = 3,
-		POINT = 4
+		POINT = 4,
+		AXIS_XR = 5
+
 	}
 
 	export class Matrix2d {
@@ -312,6 +314,10 @@ namespace pixi_projection {
 					D /= Math.sqrt(matrix.a * matrix.a + matrix.c * matrix.c);
 					matrix.a = D;
 					matrix.c = 0;
+				}
+				else if (affine === AFFINE.AXIS_XR) {
+                    matrix.a =  matrix.d * D;
+					matrix.c = -matrix.b * D;
 				}
 			}
 		}


### PR DESCRIPTION
hybrid between AXIS_X"2"  without iso rotation
![preserveRot](https://user-images.githubusercontent.com/24865815/54881158-737e7500-4e23-11e9-8bab-296fb446369c.gif)

Allow to use rotation on a projection without isometric transformations linked to rotation.