### PR TITLE
In pixi v5 filterManager is now filter

### DIFF
--- a/src/proj2d/z_masks/MaskHacker.ts
+++ b/src/proj2d/z_masks/MaskHacker.ts
@@ -12,7 +12,7 @@ namespace pixi_projection {
 		// TODO - may cause issues!
 		target.filterArea = maskData.getBounds(true);
 
-		this.renderer.filterManager.pushFilter(target, alphaMaskFilter);
+		this.renderer.filter.push(target, alphaMaskFilter);
 
 		this.alphaMaskIndex++;
 	}


### PR DESCRIPTION
Didn't find an existing issue, but hit this in my code. This change fixes the issue and was tested.