### PR TITLE
fix worldTransform from getLocalPosition

### DIFF
--- a/src/proj2d/sprites/Sprite2d.ts
+++ b/src/proj2d/sprites/Sprite2d.ts
@@ -150,7 +150,7 @@ namespace pixi_projection {
         }
 
         get worldTransform() {
-            return this.proj.affine ? this.transform.worldTransform : this.proj.world as any;
+            return isNaN(this.proj.affine) ? this.proj.world : this.transform.worldTransform as any;
         }
     }
 }


### PR DESCRIPTION
Let fix this annoying bug. :)

see : https://www.pixiplayground.com/#/edit/WmmaczN22ZydRizFuz1~z
line: 162

and step inside `displayObject.worldTransform.applyInverse`.
In the demo when mouse is out the bounds, you should see red coord in the mouse.
Also coor are not ok if you move camera.
