### PR TITLE
Fix potential exception in SimpleMesh2d._renderDefault

### DIFF
--- a/src/proj2d/mesh/Mesh2d.ts
+++ b/src/proj2d/mesh/Mesh2d.ts
@@ -114,7 +114,7 @@ gl_FragColor = texture2D(uSampler, vTextureCoord) * uColor;
 
         renderer.batch.flush();
 
-        if ((shader as any).program.uniformData.translationMatrix)
+        if ((shader as any).program.uniformData?.translationMatrix)
         {
             shader.uniforms.translationMatrix = this.worldTransform.toArray(true);
         }


### PR DESCRIPTION
Hello,

PR fixes potential exception raised by SimpleMesh2d._renderDefault.

```
TypeError
Cannot read properties of undefined (reading 'translationMatrix')
Call Stack
 SimpleMesh2d._renderDefault
  node_modules/pixi-projection/lib/pixi-projection.es.js:1613:43
 SimpleMesh2d.Mesh._render
  node_modules/@pixi/mesh/dist/esm/mesh.js:374:18
 SimpleMesh2d._render
  node_modules/pixi-projection/lib/pixi-projection.es.js:1677:25
 SimpleMesh2d.Container.render [as containerRenderWebGL]
  node_modules/@pixi/display/dist/esm/display.js:2370:18
 SimpleMesh2d.containerRender [as render]
  node_modules/@pixi/layers/lib/pixi-layers.es.js:64:10
 Container2d.Container.render [as containerRenderWebGL]
  node_modules/@pixi/display/dist/esm/display.js:2373:34
 Container2d.containerRender [as render]
  node_modules/@pixi/layers/lib/pixi-layers.es.js:64:10
 SpineProjection.Container.render [as containerRenderWebGL]
  node_modules/@pixi/display/dist/esm/display.js:2373:34
 SpineProjection.containerRender [as render]
  node_modules/@pixi/layers/lib/pixi-layers.es.js:64:10
 Container.render [as containerRenderWebGL]
  node_modules/@pixi/display/dist/esm/display.js:2373:34
```

In my case it is raised when I try to render projected spine with mesh.
@ivanpopelyshev would be perfect if you could release new version.