### PR TITLE
`sample` is a reserved word in some opengl versions

### DIFF
--- a/src/proj2d/tiling/TilingSprite2dRenderer.ts
+++ b/src/proj2d/tiling/TilingSprite2dRenderer.ts
@@ -35,8 +35,8 @@ vec2 coord = mod(vTextureCoord.xy / vTextureCoord.z - uClampOffset, vec2(1.0, 1.
 coord = (uMapCoord * vec3(coord, 1.0)).xy;
 coord = clamp(coord, uClampFrame.xy, uClampFrame.zw);
 
-vec4 sample = texture2D(uSampler, coord);
-gl_FragColor = sample * uColor;
+vec4 _sample = texture2D(uSampler, coord);
+gl_FragColor = _sample * uColor;
 }
 `;
 const shaderSimpleFrag = `
@@ -47,8 +47,8 @@ uniform vec4 uColor;
 
 void main(void)
 {
-vec4 sample = texture2D(uSampler, vTextureCoord.xy / vTextureCoord.z);
-gl_FragColor = sample * uColor;
+vec4 _sample = texture2D(uSampler, vTextureCoord.xy / vTextureCoord.z);
+gl_FragColor = _sample * uColor;
 }
 `;
 


### PR DESCRIPTION
We're using pixi-projection with node-gl for server-sided video rendering. Since node-gl uses native OpenGL bindings, we ran into the issue where `sample` is a reserved keyword in some OpenGL versions (actually in most OpenGL versions, i think).

This PR fixes this by changing the `sample` variable to `_sample`. LMK if you'd prefer a different name!